### PR TITLE
Fix example in Chrome

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -16,7 +16,7 @@
       if (key === ':') {
         const menu = document.createElement('ul')
         const item = document.createElement('li')
-        item.role = 'option'
+        item.setAttribute('role', 'option')
         item.textContent = '🐈'
         menu.append(item)
         provide(Promise.resolve({matched: true, fragment: menu}))
@@ -34,4 +34,3 @@
   <!-- <script src="../dist/index.umd.js"></script> -->
 </body>
 </html>
-


### PR DESCRIPTION
The ARIA IDL interface is fairly new and not yet implemented in Chrome & Firefox. https://w3c.github.io/aria/#idl-interface (does not exist in WAI-ARIA 1.1).

I believe the example page has never worked in Chrome due to this. This can be checked with `'role' in document.createElement('div')`, which is false in Chrome and Firefox, but true in Safari.

@koddsson can you run this locally to verify that it works for you with this change?

cc @haacked