### PR TITLE
Update readme with a more realistic example and explain event.detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The returned fragment should be consisted of filtered `[role=option]` items to b
 **`text-expander-value`** is fired when an item is selected. In `event.detail` you can find:
 
 - `key`: The matched key; for example: `:`.
-- `item`: The matched text; for example: `cat`, for `:cat`.
+- `item`: The selected item. This would be one of the `[role=option]`. Use this to work out the `value`.
 - `value`: A null value placeholder to replace the query. To replace the text query, simply re-assign this value.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -26,25 +26,52 @@ import '@github/text-expander-element'
 
 ## Events
 
+**`text-expander-change`** is fired when a key is matched. In `event.detail` you can find:
+
+- `key`: The matched key; for example: `:`.
+- `text`: The matched text; for example: `cat`, for `:cat`.
+- `provider`: A function to be called when you have the menu results. Takes a `Promise` with `{matched: boolean, fragment: HTMLElement}` where `matched` tells the element whether a suggestion is available, and `fragment` is the menu content to be displayed on the page.
+
 ```js
 const expander = document.querySelector('text-expander')
 
 expander.addEventListener('text-expander-change', function(event) {
-  const {key, provide} = event.detail
-  if (key === ':') {
-    const menu = document.createElement('ul')
-    const item = document.createElement('li')
-    item.textContent = '🐈'
-    item.role = 'option'
-    menu.append(item)
-    provide(Promise.resolve({matched: true, fragment: menu}))
+  const {key, provide, text} = event.detail
+  if (key !== ':') return
+
+  const suggestions = document.querySelector('.emoji-suggestions').cloneNode(true)
+  suggestions.hidden = false
+  for (const suggestion of suggestions.children) {
+    if (!suggestion.textContent.match(text)) {
+      suggestion.remove()
+    }
   }
+  provide(Promise.resolve({matched: suggestions.childElementCount > 0, fragment: suggestions}))
 })
+```
+
+The returned fragment should be consisted of filtered `[role=option]` items to be selected. For example:
+
+```html
+<ul class="emoji-suggestions" hidden>
+  <li role="option" data-value="🐈">🐈 :cat2:</li>
+  <li role="option" data-value="🐕">🐕 :dog:</li>
+</ul>
+```
+
+**`text-expander-value`** is fired when an item is selected. In `event.detail` you can find:
+
+- `key`: The matched key; for example: `:`.
+- `item`: The matched text; for example: `cat`, for `:cat`.
+- `value`: A null value placeholder to replace the query. To replace the text query, simply re-assign this value.
+
+```js
+const expander = document.querySelector('text-expander')
 
 expander.addEventListener('text-expander-value', function(event) {
   const {key, item}  = event.detail
   if (key === ':') {
-    event.detail.value = '🐈'
+    event.detail.value = item.getAttribute('data-value')
   }
 })
 ```


### PR DESCRIPTION
Ref: https://github.com/github/text-expander-element/pull/3#issuecomment-513858403. This updates the README code with a more realistic example.

In the real world, instead of rendering the suggestions on the page and filtering on client side, people may `fetch('/emoji?q=' + text)` to get filtered suggestions from the server side. 

On github.com we first fetch, then memoize the fetch response, and then perform client side filtering.

The element code is extracted in this way so it does not dictate filtering and content generation logic. 

cc @haacked