### PR TITLE
Add TS window declaration for TextExpanderElement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,9 @@
 export default class TextExpanderElement extends HTMLElement {
   readonly keys: Array<string>;
 }
+
+declare global {
+  interface Window {
+    TextExpanderElement: typeof TextExpanderElement
+  }
+}


### PR DESCRIPTION
The TypeScript definition is incomplete as it doesn't properly reflect the assignment to Window.

This PR adds the declaration of `TextExpanderElement` to the global window object, as that mutation is happening within the code and so should be reflected in the types.

 Refs https://github.com/github/application-architecture/issues/58