### PR TITLE
Prevent `multiword` mode from matching when there's a space immediately after activation key

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -12,6 +12,10 @@ export default function query(text: string, key: string, cursor: number, multiWo
   if (keyIndex === -1) return
 
   if (multiWord) {
+    // Space immediately after activation key
+    const charAfterKey = text[keyIndex + 1]
+    if (charAfterKey === ' ') return
+
     // New line the cursor and previous activation key.
     const newLineIndex = text.lastIndexOf('\n', cursor - 1)
     if (newLineIndex > keyIndex) return

--- a/test/keyword-test.js
+++ b/test/keyword-test.js
@@ -113,6 +113,11 @@ describe('text-expander multi word parsing', function() {
     assert.deepEqual(found, {text: 'cat bye', position: 4})
   })
 
+  it('does not match with a dot between cursor and activation key', function() {
+    const found = query('hi :cat. bye', ':', 11, true)
+    assert(found == null)
+  })
+
   it('does not match with a space between text and activation key', function() {
     const found = query('hi : cat bye', ':', 7, true)
     assert(found == null)

--- a/test/keyword-test.js
+++ b/test/keyword-test.js
@@ -58,6 +58,11 @@ describe('text-expander single word parsing', function() {
 })
 
 describe('text-expander multi word parsing', function() {
+  it('does not match empty text', function() {
+    const found = query('', ':', 0, true)
+    assert(found == null)
+  })
+
   it('does not match without activation key', function() {
     const found = query('cat', ':', 3, true)
     assert(found == null)
@@ -73,18 +78,33 @@ describe('text-expander multi word parsing', function() {
     assert.deepEqual(found, {text: '', position: 4})
   })
 
+  it('matches start of text', function() {
+    const found = query(':cat', ':', 4, true)
+    assert.deepEqual(found, {text: 'cat', position: 1})
+  })
+
+  it('matches end of text', function() {
+    const found = query('hi :cat', ':', 7, true)
+    assert.deepEqual(found, {text: 'cat', position: 4})
+  })
+
+  it('matches middle of text', function() {
+    const found = query('hi :cat bye', ':', 7, true)
+    assert.deepEqual(found, {text: 'cat', position: 4})
+  })
+
   it('matches only at word boundary', function() {
-    const found = query('hi:cat', ':', 6)
+    const found = query('hi:cat', ':', 6, true)
     assert(found == null)
   })
 
   it('matches last activation key word', function() {
-    const found = query('hi :cat bye :dog', ':', 16)
+    const found = query('hi :cat bye :dog', ':', 16, true)
     assert.deepEqual(found, {text: 'dog', position: 13})
   })
 
   it('matches closest activation key word', function() {
-    const found = query('hi :cat bye :dog', ':', 7)
+    const found = query('hi :cat bye :dog', ':', 7, true)
     assert.deepEqual(found, {text: 'cat', position: 4})
   })
 

--- a/test/keyword-test.js
+++ b/test/keyword-test.js
@@ -58,8 +58,43 @@ describe('text-expander single word parsing', function() {
 })
 
 describe('text-expander multi word parsing', function() {
+  it('does not match without activation key', function() {
+    const found = query('cat', ':', 3, true)
+    assert(found == null)
+  })
+
+  it('matches only activation key', function() {
+    const found = query(':', ':', 1, true)
+    assert.deepEqual(found, {text: '', position: 1})
+  })
+
+  it('matches trailing activation key', function() {
+    const found = query('hi :', ':', 4, true)
+    assert.deepEqual(found, {text: '', position: 4})
+  })
+
+  it('matches only at word boundary', function() {
+    const found = query('hi:cat', ':', 6)
+    assert(found == null)
+  })
+
+  it('matches last activation key word', function() {
+    const found = query('hi :cat bye :dog', ':', 16)
+    assert.deepEqual(found, {text: 'dog', position: 13})
+  })
+
+  it('matches closest activation key word', function() {
+    const found = query('hi :cat bye :dog', ':', 7)
+    assert.deepEqual(found, {text: 'cat', position: 4})
+  })
+
   it('does matches with a space between cursor and activation key', function() {
     const found = query('hi :cat bye', ':', 11, true)
     assert.deepEqual(found, {text: 'cat bye', position: 4})
+  })
+
+  it('does not match with a space between query and activation key', function() {
+    const found = query('hi : cat bye', ':', 7, true)
+    assert(found == null)
   })
 })

--- a/test/keyword-test.js
+++ b/test/keyword-test.js
@@ -88,12 +88,12 @@ describe('text-expander multi word parsing', function() {
     assert.deepEqual(found, {text: 'cat', position: 4})
   })
 
-  it('does matches with a space between cursor and activation key', function() {
+  it('matches with a space between cursor and activation key', function() {
     const found = query('hi :cat bye', ':', 11, true)
     assert.deepEqual(found, {text: 'cat bye', position: 4})
   })
 
-  it('does not match with a space between query and activation key', function() {
+  it('does not match with a space between text and activation key', function() {
     const found = query('hi : cat bye', ':', 7, true)
     assert(found == null)
   })


### PR DESCRIPTION
This regression was introduced in https://github.com/github/text-expander-element/pull/14 and only affects `multiword` mode. 

This PR fixes the issue and adds more tests to cover the code and protect from potential regressions.  