### PR TITLE
only stop the ESC keydown event propagation if menu or combobox present

### DIFF
--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -187,10 +187,11 @@ class TextExpander {
   }
 
   onKeydown(event: KeyboardEvent) {
-    if (event.key !== 'Escape' && (!this.menu || !this.combobox)) return
-    this.deactivate()
-    event.stopImmediatePropagation()
-    event.preventDefault()
+    if (event.key === 'Escape' && (this.menu || this.combobox)) {
+      this.deactivate()
+      event.stopImmediatePropagation()
+      event.preventDefault()
+    }
   }
 }
 

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -188,11 +188,10 @@ class TextExpander {
 
   onKeydown(event: KeyboardEvent) {
     if (event.key !== 'Escape') return
+    if (!this.menu || !this.combobox) return
     this.deactivate()
-    if (this.menu || this.combobox) {
-      event.stopImmediatePropagation()
-      event.preventDefault()
-    }
+    event.stopImmediatePropagation()
+    event.preventDefault()
   }
 }
 

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -187,8 +187,7 @@ class TextExpander {
   }
 
   onKeydown(event: KeyboardEvent) {
-    if (event.key !== 'Escape') return
-    if (!this.menu || !this.combobox) return
+    if (event.key !== 'Escape' && (!this.menu || !this.combobox)) return
     this.deactivate()
     event.stopImmediatePropagation()
     event.preventDefault()

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -189,8 +189,10 @@ class TextExpander {
   onKeydown(event: KeyboardEvent) {
     if (event.key !== 'Escape') return
     this.deactivate()
-    event.stopImmediatePropagation()
-    event.preventDefault()
+    if (this.menu || this.combobox) {
+      event.stopImmediatePropagation()
+      event.preventDefault()
+    }
   }
 }
 


### PR DESCRIPTION
Related: https://github.com/github/issues/issues/1097

It seems the `event.stopImmediatePropagation()` prevents ESC keydown events from being triggered from a textarea within `text-expander-element` even when the menu is not present. 

This PR introduces a new condition to the initial `if` statement that check if the element's menu or combobox is present and returns if they are not, so that this eventlistener doesn't interfere with the propagation of the ESC key press when the menu is not activated.