### PR TITLE
Set combobox to null when deactivate

### DIFF
--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -90,6 +90,7 @@ class TextExpander {
     const menu = this.menu
     if (!menu || !this.combobox) return
     this.menu = null
+    this.combobox = null
 
     menu.removeEventListener('combobox-commit', this.oncommit)
     menu.removeEventListener('mousedown', this.onmousedown)

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -90,11 +90,11 @@ class TextExpander {
     const menu = this.menu
     if (!menu || !this.combobox) return
     this.menu = null
-    this.combobox = null
 
     menu.removeEventListener('combobox-commit', this.oncommit)
     menu.removeEventListener('mousedown', this.onmousedown)
     this.combobox.destroy()
+    this.combobox = null
     menu.remove()
   }
 


### PR DESCRIPTION
Related to: https://github.com/github/issues/issues/1097

Both the menu and combobox need to be set to null to deactivate them, otherwise there is always a combobox present after the first time the text-expander-element is triggered and will not register ESC keypresses anymore in the component after this element is activated.

**Update:**
I looked at the [combobox-nav package at the `destroy()` method](https://github.com/github/combobox-nav/blob/main/src/index.ts#L32), looks like it removed a bunch of attributes and removes eventlisteners. i still think it should be set to null so i moved that to end of `deactivate()` method.