### PR TITLE
For multiword scenarios, ignore activation keys when a match is in progress.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ With a script tag:
 
 - `key`: The matched key; for example: `:`.
 - `text`: The matched text; for example: `cat`, for `:cat`.
+  - If the `key` is specified in the `multiword` attribute then the matched text can contain multiple words; for example `cat and dog` for `:cat and dog`.
 - `provide`: A function to be called when you have the menu results. Takes a `Promise` with `{matched: boolean, fragment: HTMLElement}` where `matched` tells the element whether a suggestion is available, and `fragment` is the menu content to be displayed on the page.
 
 ```js

--- a/examples/index.html
+++ b/examples/index.html
@@ -19,7 +19,7 @@
     </text-expander>
 
     <h2>Multiword text-expander element</h2>
-    <text-expander keys="#" multiword>
+    <text-expander keys="#" multiword="#">
       <textarea autofocus rows="10" cols="40"></textarea>
     </text-expander>
 
@@ -34,7 +34,9 @@
             for (const issue of [
               '#1 Implement a text-expander element',
               '#2 Implement multi word option',
-              '#3 Fix tpoy'
+              '#3 Fix tpoy',
+              '#4 Implement #12',
+              '#5 Implement #123 and #456',
             ]) {
               if (issue.toLowerCase().includes(text.toLowerCase())) {
                 const item = document.createElement('li')

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,3 +1,5 @@
+import {Match} from './text-expander-element'
+
 type Query = {
   text: string
   position: number
@@ -6,8 +8,7 @@ type Query = {
 type QueryOptions = {
   lookBackIndex: number
   multiWord: boolean
-  matchInProgress: boolean
-  currentMatchIndex: number
+  match: Match | null
 }
 
 const boundary = /\s|\(|\[/
@@ -17,11 +18,10 @@ export default function query(
   text: string,
   key: string,
   cursor: number,
-  {multiWord, lookBackIndex, matchInProgress, currentMatchIndex}: QueryOptions = {
+  {multiWord, lookBackIndex, match}: QueryOptions = {
     multiWord: false,
     lookBackIndex: 0,
-    matchInProgress: false,
-    currentMatchIndex: 0
+    match: null
   }
 ): Query | void {
   // Activation key not found in front of the cursor.
@@ -29,8 +29,8 @@ export default function query(
   if (keyIndex === -1) return
 
   if (multiWord) {
-    if (matchInProgress) {
-      keyIndex = currentMatchIndex - 1
+    if (match) {
+      keyIndex = match.position - 1
     }
 
     // Stop matching at the lookBackIndex

--- a/src/query.ts
+++ b/src/query.ts
@@ -36,9 +36,9 @@ export default function query(
       keyIndex = previousMatch.position - 1
     }
 
-    // Space immediately after activation key
+    // Space immediately after activation key followed by the cursor
     const charAfterKey = text[keyIndex + 1]
-    if (charAfterKey === ' ') return
+    if (charAfterKey === ' ' && cursor === keyIndex + 2) return
 
     // New line the cursor and previous activation key.
     const newLineIndex = text.lastIndexOf('\n', cursor - 1)

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,5 +1,3 @@
-import {Match} from './text-expander-element'
-
 type Query = {
   text: string
   position: number
@@ -8,7 +6,7 @@ type Query = {
 type QueryOptions = {
   lookBackIndex: number
   multiWord: boolean
-  previousMatch: Match | null
+  lastMatchPosition: number | null
 }
 
 const boundary = /\s|\(|\[/
@@ -18,10 +16,10 @@ export default function query(
   text: string,
   key: string,
   cursor: number,
-  {multiWord, lookBackIndex, previousMatch}: QueryOptions = {
+  {multiWord, lookBackIndex, lastMatchPosition}: QueryOptions = {
     multiWord: false,
     lookBackIndex: 0,
-    previousMatch: null
+    lastMatchPosition: null
   }
 ): Query | void {
   // Activation key not found in front of the cursor.
@@ -32,13 +30,13 @@ export default function query(
   if (keyIndex < lookBackIndex) return
 
   if (multiWord) {
-    if (previousMatch) {
-      keyIndex = previousMatch.position - 1
+    if (lastMatchPosition !== null) {
+      keyIndex = lastMatchPosition - 1
     }
 
     // Space immediately after activation key followed by the cursor
     const charAfterKey = text[keyIndex + 1]
-    if (charAfterKey === ' ' && cursor === keyIndex + 2) return
+    if (charAfterKey === ' ' && cursor >= keyIndex + 2) return
 
     // New line the cursor and previous activation key.
     const newLineIndex = text.lastIndexOf('\n', cursor - 1)

--- a/src/query.ts
+++ b/src/query.ts
@@ -30,7 +30,7 @@ export default function query(
   if (keyIndex < lookBackIndex) return
 
   if (multiWord) {
-    if (lastMatchPosition !== null) {
+    if (lastMatchPosition != null) {
       // If the current activation key is the same as last match
       // i.e. consecutive activation keys, then return.
       if (lastMatchPosition === keyIndex) return

--- a/src/query.ts
+++ b/src/query.ts
@@ -7,6 +7,7 @@ type QueryOptions = {
   lookBackIndex: number
   multiWord: boolean
   matchInProgress: boolean
+  currentMatchIndex: number
 }
 
 const boundary = /\s|\(|\[/
@@ -16,10 +17,11 @@ export default function query(
   text: string,
   key: string,
   cursor: number,
-  {multiWord, lookBackIndex, matchInProgress}: QueryOptions = {
+  {multiWord, lookBackIndex, matchInProgress, currentMatchIndex}: QueryOptions = {
     multiWord: false,
     lookBackIndex: 0,
-    matchInProgress: false
+    matchInProgress: false,
+    currentMatchIndex: 0
   }
 ): Query | void {
   // Activation key not found in front of the cursor.
@@ -28,7 +30,7 @@ export default function query(
 
   if (multiWord) {
     if (matchInProgress) {
-      keyIndex = lookBackIndex
+      keyIndex = currentMatchIndex - 1
     }
 
     // Stop matching at the lookBackIndex

--- a/src/query.ts
+++ b/src/query.ts
@@ -31,6 +31,9 @@ export default function query(
 
   if (multiWord) {
     if (lastMatchPosition !== null) {
+      // If the current activation key is the same as last match
+      // i.e. consecutive activation keys, then return.
+      if (lastMatchPosition === keyIndex) return
       keyIndex = lastMatchPosition - 1
     }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -6,6 +6,7 @@ type Query = {
 type QueryOptions = {
   lookBackIndex: number
   multiWord: boolean
+  matchInProgress: boolean
 }
 
 const boundary = /\s|\(|\[/
@@ -15,13 +16,21 @@ export default function query(
   text: string,
   key: string,
   cursor: number,
-  {multiWord, lookBackIndex}: QueryOptions = {multiWord: false, lookBackIndex: 0}
+  {multiWord, lookBackIndex, matchInProgress}: QueryOptions = {
+    multiWord: false,
+    lookBackIndex: 0,
+    matchInProgress: false
+  }
 ): Query | void {
   // Activation key not found in front of the cursor.
-  const keyIndex = text.lastIndexOf(key, cursor - 1)
+  let keyIndex = text.lastIndexOf(key, cursor - 1)
   if (keyIndex === -1) return
 
   if (multiWord) {
+    if (matchInProgress) {
+      keyIndex = lookBackIndex
+    }
+
     // Stop matching at the lookBackIndex
     if (keyIndex < lookBackIndex) return
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -8,7 +8,7 @@ type Query = {
 type QueryOptions = {
   lookBackIndex: number
   multiWord: boolean
-  match: Match | null
+  previousMatch: Match | null
 }
 
 const boundary = /\s|\(|\[/
@@ -18,10 +18,10 @@ export default function query(
   text: string,
   key: string,
   cursor: number,
-  {multiWord, lookBackIndex, match}: QueryOptions = {
+  {multiWord, lookBackIndex, previousMatch}: QueryOptions = {
     multiWord: false,
     lookBackIndex: 0,
-    match: null
+    previousMatch: null
   }
 ): Query | void {
   // Activation key not found in front of the cursor.
@@ -29,8 +29,8 @@ export default function query(
   if (keyIndex === -1) return
 
   if (multiWord) {
-    if (match) {
-      keyIndex = match.position - 1
+    if (previousMatch) {
+      keyIndex = previousMatch.position - 1
     }
 
     // Stop matching at the lookBackIndex

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -135,6 +135,7 @@ class TextExpander {
     this.input.selectionStart = cursor
     this.input.selectionEnd = cursor
     this.lookBackIndex = cursor
+    this.match = null
   }
 
   private onBlur() {
@@ -179,7 +180,7 @@ class TextExpander {
     const cursor = this.input.selectionEnd || 0
     const text = this.input.value
     if (cursor <= this.lookBackIndex) {
-      this.lookBackIndex = 0
+      this.lookBackIndex = cursor - 1
     }
     for (const {key, multiWord} of this.expander.keys) {
       const found = query(text, key, cursor, {
@@ -212,8 +213,8 @@ class TextExpander {
 
   private onKeydown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
+      this.match = null
       if (this.deactivate()) {
-        this.match = null
         this.lookBackIndex = this.input.selectionEnd || this.lookBackIndex
         event.stopImmediatePropagation()
         event.preventDefault()

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -2,7 +2,7 @@ import Combobox from '@github/combobox-nav'
 import query from './query'
 import textFieldSelectionPosition from './text-field-selection-position'
 
-type Match = {
+export type Match = {
   text: string
   key: string
   position: number
@@ -32,8 +32,6 @@ class TextExpander {
   onmousedown: (event: Event) => void
   combobox: Combobox | null
   match: Match | null
-  matchInProgress: boolean
-  currentMatchIndex: number
   justPasted: boolean
   lookBackIndex: number
   interactingWithList: boolean
@@ -44,8 +42,6 @@ class TextExpander {
     this.combobox = null
     this.menu = null
     this.match = null
-    this.matchInProgress = false
-    this.currentMatchIndex = 0
     this.justPasted = false
     this.lookBackIndex = 0
     this.oninput = this.onInput.bind(this)
@@ -72,8 +68,6 @@ class TextExpander {
     if (this.input !== document.activeElement) return
 
     this.deactivate()
-    this.matchInProgress = true
-    this.currentMatchIndex = match.position
     this.menu = menu
 
     if (!menu.id) menu.id = `text-expander-${Math.floor(Math.random() * 100000).toString()}`
@@ -102,8 +96,6 @@ class TextExpander {
     this.combobox.destroy()
     this.combobox = null
     menu.remove()
-    this.matchInProgress = false
-    this.currentMatchIndex = 0
   }
 
   onCommit({target}: Event) {
@@ -184,8 +176,7 @@ class TextExpander {
       const found = query(text, key, cursor, {
         multiWord,
         lookBackIndex: this.lookBackIndex,
-        matchInProgress: this.matchInProgress,
-        currentMatchIndex: this.currentMatchIndex
+        match: this.match
       })
       if (found) {
         return {text: found.text, key, position: found.position}
@@ -213,6 +204,7 @@ class TextExpander {
   onKeydown(event: KeyboardEvent) {
     if (event.key === 'Escape' && (this.menu || this.combobox)) {
       this.deactivate()
+      this.match = null
       event.stopImmediatePropagation()
       event.preventDefault()
     }

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -33,6 +33,7 @@ class TextExpander {
   combobox: Combobox | null
   match: Match | null
   matchInProgress: boolean
+  currentMatchIndex: number
   justPasted: boolean
   lookBackIndex: number
   interactingWithList: boolean
@@ -44,6 +45,7 @@ class TextExpander {
     this.menu = null
     this.match = null
     this.matchInProgress = false
+    this.currentMatchIndex = 0
     this.justPasted = false
     this.lookBackIndex = 0
     this.oninput = this.onInput.bind(this)
@@ -71,6 +73,7 @@ class TextExpander {
 
     this.deactivate()
     this.matchInProgress = true
+    this.currentMatchIndex = match.position
     this.menu = menu
 
     if (!menu.id) menu.id = `text-expander-${Math.floor(Math.random() * 100000).toString()}`
@@ -100,6 +103,7 @@ class TextExpander {
     this.combobox = null
     menu.remove()
     this.matchInProgress = false
+    this.currentMatchIndex = 0
   }
 
   onCommit({target}: Event) {
@@ -180,7 +184,8 @@ class TextExpander {
       const found = query(text, key, cursor, {
         multiWord,
         lookBackIndex: this.lookBackIndex,
-        matchInProgress: this.matchInProgress
+        matchInProgress: this.matchInProgress,
+        currentMatchIndex: this.currentMatchIndex
       })
       if (found) {
         return {text: found.text, key, position: found.position}

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -2,7 +2,7 @@ import Combobox from '@github/combobox-nav'
 import query from './query'
 import textFieldSelectionPosition from './text-field-selection-position'
 
-export type Match = {
+type Match = {
   text: string
   key: string
   position: number
@@ -186,7 +186,7 @@ class TextExpander {
       const found = query(text, key, cursor, {
         multiWord,
         lookBackIndex: this.lookBackIndex,
-        previousMatch: this.match
+        lastMatchPosition: this.match ? this.match.position : null
       })
       if (found) {
         return {text: found.text, key, position: found.position}

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -176,7 +176,7 @@ class TextExpander {
       const found = query(text, key, cursor, {
         multiWord,
         lookBackIndex: this.lookBackIndex,
-        match: this.match
+        previousMatch: this.match
       })
       if (found) {
         return {text: found.text, key, position: found.position}

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -32,6 +32,7 @@ class TextExpander {
   onmousedown: (event: Event) => void
   combobox: Combobox | null
   match: Match | null
+  matchInProgress: boolean
   justPasted: boolean
   lookBackIndex: number
   interactingWithList: boolean
@@ -42,6 +43,7 @@ class TextExpander {
     this.combobox = null
     this.menu = null
     this.match = null
+    this.matchInProgress = false
     this.justPasted = false
     this.lookBackIndex = 0
     this.oninput = this.onInput.bind(this)
@@ -68,6 +70,7 @@ class TextExpander {
     if (this.input !== document.activeElement) return
 
     this.deactivate()
+    this.matchInProgress = true
     this.menu = menu
 
     if (!menu.id) menu.id = `text-expander-${Math.floor(Math.random() * 100000).toString()}`
@@ -96,6 +99,7 @@ class TextExpander {
     this.combobox.destroy()
     this.combobox = null
     menu.remove()
+    this.matchInProgress = false
   }
 
   onCommit({target}: Event) {
@@ -173,7 +177,11 @@ class TextExpander {
       this.lookBackIndex = 0
     }
     for (const {key, multiWord} of this.expander.keys) {
-      const found = query(text, key, cursor, {multiWord, lookBackIndex: this.lookBackIndex})
+      const found = query(text, key, cursor, {
+        multiWord,
+        lookBackIndex: this.lookBackIndex,
+        matchInProgress: this.matchInProgress
+      })
       if (found) {
         return {text: found.text, key, position: found.position}
       }

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -122,6 +122,26 @@ describe('text-expander multi word parsing', function() {
     const found = query('hi : cat bye', ':', 7, {multiWord: true})
     assert(found == null)
   })
+
+  it('does not match consecutive activation keys', function() {
+    let found = query('::', ':', 2, {multiWord: true})
+    assert(found == null)
+
+    found = query('::', ':', 3, {multiWord: true})
+    assert(found == null)
+
+    found = query('hi :: there', ':', 5, {multiWord: true})
+    assert(found == null)
+
+    found = query('hi ::: there', ':', 6, {multiWord: true})
+    assert(found == null)
+
+    found = query('hi ::', ':', 5, {multiWord: true})
+    assert(found == null)
+
+    found = query('hi :::', ':', 6, {multiWord: true})
+    assert(found == null)
+  })
 })
 
 describe('text-expander limits the lookBack after commit', function() {

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -122,7 +122,9 @@ describe('text-expander multi word parsing', function() {
     const found = query('hi : cat bye', ':', 7, {multiWord: true})
     assert(found == null)
   })
+})
 
+describe('text-expander multi word parsing with multiple activation keys', function() {
   it('does not match consecutive activation keys', function() {
     let found = query('::', ':', 2, {multiWord: true})
     assert(found == null)
@@ -141,6 +143,17 @@ describe('text-expander multi word parsing', function() {
 
     found = query('hi :::', ':', 6, {multiWord: true})
     assert(found == null)
+  })
+
+  it('uses lastMatchPosition to match', function() {
+    let found = query('hi :cat :bye', ':', 12, {multiWord: true, lastMatchPosition: 4})
+    assert.deepEqual(found, {text: 'cat :bye', position: 4})
+
+    found = query('hi :cat :bye :::', ':', 16, {multiWord: true, lastMatchPosition: 4})
+    assert.deepEqual(found, {text: 'cat :bye :::', position: 4})
+
+    found = query(':hi :cat :bye :::', ':', 17, {multiWord: true, lastMatchPosition: 1})
+    assert.deepEqual(found, {text: 'hi :cat :bye :::', position: 1})
   })
 })
 

--- a/test/text-expander-element-test.js
+++ b/test/text-expander-element-test.js
@@ -128,6 +128,36 @@ describe('text-expander element', function() {
       assert.equal('#', key)
       assert.equal('some text @match word', text)
     })
+
+    it('dispatches change event for the first activation key even if it is typed again', async function() {
+      const expander = document.querySelector('text-expander')
+      const input = expander.querySelector('textarea')
+
+      let result = once(expander, 'text-expander-change')
+      triggerInput(input, '#step 1')
+      let event = await result
+      let {key, text} = event.detail
+      assert.equal('#', key)
+      assert.equal('step 1', text)
+
+      await waitForAnimationFrame()
+
+      result = once(expander, 'text-expander-change')
+      triggerInput(input, ' #step 2', true) //<-- At this point the text inside the input field is "#step 1 #step 2"
+      event = await result
+      ;({key, text} = event.detail)
+      assert.equal('#', key)
+      assert.equal('step 1 #step 2', text)
+
+      await waitForAnimationFrame()
+
+      result = once(expander, 'text-expander-change')
+      triggerInput(input, ' #step 3', true) //<-- At this point the text inside the input field is "#step 1 #step 2 #step 3"
+      event = await result
+      ;({key, text} = event.detail)
+      assert.equal('#', key)
+      assert.equal('step 1 #step 2 #step 3', text)
+    })
   })
 })
 
@@ -137,8 +167,8 @@ function once(element, eventName) {
   })
 }
 
-function triggerInput(input, value) {
-  input.value = value
+function triggerInput(input, value, onlyAppend = false) {
+  input.value = onlyAppend ? input.value + value : value
   return input.dispatchEvent(new InputEvent('input'))
 }
 


### PR DESCRIPTION
This PR adds the following behaviour to the `text-expander-element`:

If an activation key is specified in the `multiword` attribute, then its first occurrence should be treated as activating and the following occurrences should be ignored (treated as normal text).

For example, let's assume the `text-expander-element` is configured as :
```
<text-expander keys=": @ #" multiword="#">
  <textarea></textarea>
</text-expander>
```

When the user types `#Implement #123`, the first `#` should be identified as the activation key and the following text `Implement #123` should be treated as the match i.e. `#123` should **NOT** create a new match. 

This gif shows the new behaviour.
![11](https://user-images.githubusercontent.com/823312/100624941-44bcdf80-3324-11eb-989f-5c7ae720fea7.gif)



