### PR TITLE
Enable multi-word expanding in the middle of text

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -25,9 +25,11 @@ export default function query(
   if (keyIndex < lookBackIndex) return
 
   if (multiWord) {
-    // Space immediately after activation key
-    const charAfterKey = text[keyIndex + 1]
-    if (charAfterKey === ' ') return
+    // Space immediately after activation key, but not cursor
+    const nextIndex = keyIndex + 1
+    const cursorAfterKey = nextIndex === cursor
+    const spaceAfterKey = text[nextIndex] === ' '
+    if (!cursorAfterKey && spaceAfterKey) return
 
     // New line the cursor and previous activation key.
     const newLineIndex = text.lastIndexOf('\n', cursor - 1)

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -55,6 +55,11 @@ describe('text-expander single word parsing', function() {
     const found = query('hi :cat bye', ':', 11)
     assert(found == null)
   })
+
+  it('matches if cursor is immediately after activation key', function() {
+    const found = query('hi : cat bye', ':', 4)
+    assert.deepEqual(found, {text: '', position: 4})
+  })
 })
 
 describe('text-expander multi word parsing', function() {
@@ -123,7 +128,7 @@ describe('text-expander multi word parsing', function() {
     assert(found == null)
   })
 
-  it('matches if cursor is immediately after the key', function() {
+  it('matches if cursor is immediately after activation key', function() {
     const found = query('hi : cat bye', ':', 4, {multiWord: true})
     assert.deepEqual(found, {text: '', position: 4})
   })

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -122,6 +122,11 @@ describe('text-expander multi word parsing', function() {
     const found = query('hi : cat bye', ':', 7, {multiWord: true})
     assert(found == null)
   })
+
+  it('matches if cursor is immediately after the key', function() {
+    const found = query('hi : cat bye', ':', 4, {multiWord: true})
+    assert.deepEqual(found, {text: '', position: 4})
+  })
 })
 
 describe('text-expander limits the lookBack after commit', function() {


### PR DESCRIPTION
Fixes multi-word expansion when activation key is inserted in the middle of existing text.

### Current behavior 
`<text-expander>` will wait for a non-space character to be entered, if the cursor is in the middle of existing text

### New behavior
`<text-expander>` ignores the space after the activation key, in case the `cursor` is immediately after the key.