### PR TITLE
Fix support for multiWord queries with activations keys longer than than 1 character

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -34,12 +34,12 @@ export default function query(
       // If the current activation key is the same as last match
       // i.e. consecutive activation keys, then return.
       if (lastMatchPosition === keyIndex) return
-      keyIndex = lastMatchPosition - 1
+      keyIndex = lastMatchPosition - key.length
     }
 
     // Space immediately after activation key followed by the cursor
     const charAfterKey = text[keyIndex + 1]
-    if (charAfterKey === ' ' && cursor >= keyIndex + 2) return
+    if (charAfterKey === ' ' && cursor >= keyIndex + key.length + 1) return
 
     // New line the cursor and previous activation key.
     const newLineIndex = text.lastIndexOf('\n', cursor - 1)

--- a/test/text-expander-element-test.js
+++ b/test/text-expander-element-test.js
@@ -74,15 +74,13 @@ describe('text-expander element', function() {
       const expander = document.querySelector('text-expander')
       const input = expander.querySelector('textarea')
 
-      let calls = 0
-      const receivedText = {}
+      const receivedText = []
       const expectedText = ['', 'a', 'ab', 'abc', 'abcd']
 
       expander.addEventListener('text-expander-change', event => {
-        calls = calls + 1
         const {key, text} = event.detail
         assert.equal('[[', key)
-        receivedText[text] = true
+        receivedText.push(text)
       })
       triggerInput(input, '[[')
       triggerInput(input, '[[a')
@@ -90,10 +88,7 @@ describe('text-expander element', function() {
       triggerInput(input, '[[abc')
       triggerInput(input, '[[abcd')
 
-      for (const text of expectedText) {
-        assert(receivedText[text], 'expected `${text}`')
-      }
-      assert.equal(5, calls)
+      assert.deepEqual(receivedText, expectedText)
     })
   })
 
@@ -139,15 +134,13 @@ describe('text-expander element', function() {
       const expander = document.querySelector('text-expander')
       const input = expander.querySelector('textarea')
 
-      let calls = 0
-      const receivedText = {}
+      const receivedText = []
       const expectedText = ['', 'a', 'ab', 'abc', 'abcd', 'abcd def']
 
       expander.addEventListener('text-expander-change', event => {
-        calls = calls + 1
         const {key, text} = event.detail
         assert.equal('[[', key)
-        receivedText[text] = true
+        receivedText.push(text)
       })
       triggerInput(input, '[[')
       triggerInput(input, '[[a')
@@ -156,10 +149,7 @@ describe('text-expander element', function() {
       triggerInput(input, '[[abcd')
       triggerInput(input, '[[abcd def')
 
-      for (const text of expectedText) {
-        assert(receivedText[text], 'expected: `${text}`')
-      }
-      assert.equal(6, calls)
+      assert.deepEqual(receivedText, expectedText)
     })
 
     it('dispatches change event for single word match after multi-word', async function() {


### PR DESCRIPTION
Hullo,

I was trying to use `[[` as a key to trigger a multiword expander dropdown when I discovered that it behaved erratically, only occasionally firing my `provides` callback.

After digging into it and stepping through the tests, I deduced that when we reset the `keyIndex`, given a `lastMatchPosition`, we probably assumed keys were always of `length` 1. Once I set it to `key.length`, my test started to pass.

I'm not very experienced with modern js, so I wasn't sure how to structure the test and I'm happy to change it provided some guidance 😉.

Cheers,