### PR TITLE
Fix active element detection in shadow root

### DIFF
--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -71,7 +71,9 @@ class TextExpander {
   }
 
   private activate(match: Match, menu: HTMLElement) {
-    if (this.input !== document.activeElement) return
+    if (this.input !== document.activeElement && this.input !== document.activeElement?.shadowRoot?.activeElement) {
+      return
+    }
 
     this.deactivate()
     this.menu = menu

--- a/test/WrapperComponent.js
+++ b/test/WrapperComponent.js
@@ -1,0 +1,27 @@
+export class WrapperComponent extends HTMLElement {
+  constructor() {
+    super()
+    const shadow = this.attachShadow({mode: 'open'})
+    const textExpander = document.createElement('text-expander')
+    textExpander.setAttribute('keys', '@')
+    const textarea = document.createElement('textarea')
+    textExpander.append(textarea)
+    shadow.appendChild(textExpander)
+  }
+
+  connectedCallback() {
+    const textExpander = this.shadowRoot.querySelector('text-expander')
+    textExpander.addEventListener('text-expander-change', function (event) {
+      const {key, provide} = event.detail
+
+      if (key !== '@') return
+
+      const suggestions = document.createElement('ul')
+      suggestions.innerHTML = `
+        <li role="option" data-value="a">a</li>
+        <li role="option" data-value="aa">aa</li>
+      `
+      provide(Promise.resolve({matched: true, fragment: suggestions}))
+    })
+  }
+}

--- a/test/text-expander-element-test.js
+++ b/test/text-expander-element-test.js
@@ -1,3 +1,5 @@
+import {WrapperComponent} from './WrapperComponent'
+
 describe('text-expander element', function () {
   describe('element creation', function () {
     it('creates from document.createElement', function () {
@@ -202,6 +204,31 @@ describe('text-expander element', function () {
       ;({key, text} = event.detail)
       assert.equal('#', key)
       assert.equal('step 1 #step 2 #step 3', text)
+    })
+  })
+
+  describe('use in customElement', function () {
+    this.beforeAll(function () {
+      customElements.define('wrapper-component', WrapperComponent)
+    })
+
+    beforeEach(function () {
+      const container = document.createElement('div')
+      container.innerHTML = '<wrapper-component></wrapper-component>'
+      document.body.append(container)
+    })
+
+    afterEach(function () {
+      document.body.innerHTML = ''
+    })
+
+    it('show results on input', async function () {
+      const component = document.querySelector('wrapper-component')
+      const input = component.shadowRoot.querySelector('textarea')
+      input.focus()
+      triggerInput(input, '@a')
+      await waitForAnimationFrame()
+      assert.exists(component.shadowRoot.querySelector('ul'))
     })
   })
 })

--- a/test/text-expander-element-test.js
+++ b/test/text-expander-element-test.js
@@ -207,7 +207,7 @@ describe('text-expander element', function () {
     })
   })
 
-  describe('use in customElement', function () {
+  describe('use inside a ShadowDOM', function () {
     this.beforeAll(function () {
       customElements.define('wrapper-component', WrapperComponent)
     })

--- a/test/text-expander-element-test.js
+++ b/test/text-expander-element-test.js
@@ -208,7 +208,7 @@ describe('text-expander element', function () {
   })
 
   describe('use inside a ShadowDOM', function () {
-    this.beforeAll(function () {
+    before(function () {
       customElements.define('wrapper-component', WrapperComponent)
     })
 


### PR DESCRIPTION
As mentioned in #24, when used inside a shadowRoot, the detection whether the input textarea is active, fails. This is because `document.activeElement` only returns the CustomElement but does not check inside its shadowRoot. This PR changes this by extending the check to also look inside the shadowRoot.

The provided test also adds a dummy CustomElement (`WrapperComponent`) to test usage inside a shadowRoot.