### PR TITLE
fix: prevent scroll upon clicking selection from suggestion list

### DIFF
--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -130,7 +130,9 @@ class TextExpander {
     const cursor = beginning.length + value.length
 
     this.deactivate()
-    this.input.focus()
+    this.input.focus({
+      preventScroll: true
+    })
 
     this.input.selectionStart = cursor
     this.input.selectionEnd = cursor


### PR DESCRIPTION
## Summary

This pull request prevents the browser from scrolling to the bottom of a `textarea` when you click a selection from the suggestion list.

Here's an example based on [`./examples/index.html`](https://github.com/github/text-expander-element/blob/main/examples/index.html):

| Before | After |
|--------|--------|
| ![before](https://user-images.githubusercontent.com/2993937/146245177-e8d5bc18-8dde-429a-a943-77d9a34e1bd2.gif) | ![after](https://user-images.githubusercontent.com/2993937/146245200-a61d44ef-f286-4108-9265-e4cca3883182.gif) |

Thanks for taking a look! ✨ 