### PR TITLE
Add `text-expander-committed` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ expander.addEventListener('text-expander-value', function(event) {
 })
 ```
 
+**`text-expander-committed`** is fired after the underlying `input` value has been updated in the DOM. In `event.detail` you can find:
+
+- `input`: The `HTMLInputElement` or `HTMLTextAreaElement` that just had `value` changes committed to the DOM.
+
+```js
+const expander = document.querySelector('text-expander')
+
+expander.addEventListener('text-expander-committed', function(event) {
+  const {input}  = event.detail
+})
+```
+
 ## Browser support
 
 Browsers without native [custom element support][support] require a [polyfill][].

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -140,6 +140,10 @@ class TextExpander {
     this.input.selectionEnd = cursor
     this.lookBackIndex = cursor
     this.match = null
+
+    this.expander.dispatchEvent(
+      new CustomEvent('text-expander-committed', {cancelable: false, detail: {input: this.input}})
+    )
   }
 
   private onBlur() {


### PR DESCRIPTION
Adding a new event, `text-expander-committed`, that is dispatched after the underlying input's DOM value has been updated.

This is useful for allowing subscribing listeners to be able to handle when the DOM is updated. The particular use case this is solving is allowing us to sync up with React state when using `text-expander`.

cc @theinterned 