### PR TITLE
Add `suffix` option to `<text-expander>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ With a script tag:
 - `keys` is a space separated list of menu activation keys
 - `multiword` defines whether the expansion should use several words or not
   - you can provide a space separated list of activation keys that should support multi-word matching
+- `suffix` is a string that is appended to the value during expansion, default is a single space character
 
 ## Events
 

--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -125,7 +125,8 @@ class TextExpander {
     if (canceled) return
 
     if (!detail.value) return
-    const value = `${detail.value} `
+    const suffix = this.expander.getAttribute('suffix') ?? ' '
+    const value = `${detail.value}${suffix}`
 
     this.input.value = beginning + value + remaining
 


### PR DESCRIPTION
Fixes: https://github.com/github/text-expander-element/issues/35

I was looking to add a test, but am not sure how. The current tests do not cover the `onCommit` function at all, the expansion mechanism is uncovered by tests it seems.