### PR TITLE
fix top-layer positioning absolute

### DIFF
--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -108,6 +108,10 @@ class TextExpander {
       const rect = this.input.getBoundingClientRect()
       top += rect.top
       left += rect.left
+      if (getComputedStyle(menu).position === 'absolute') {
+        top += window.scrollY
+        left += window.scrollX
+      }
     }
     menu.style.top = `${top}px`
     menu.style.left = `${left}px`


### PR DESCRIPTION
If a top-layer has position: absolute then window scrollX/Y should be accounted for.