### PR TITLE
Update `dom-input-range` to fix `DOMException` errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.0.2",
-        "dom-input-range": "^1.1.3"
+        "dom-input-range": "^1.1.6"
       },
       "devDependencies": {
         "@github/prettier-config": "0.0.4",
@@ -1674,9 +1674,9 @@
       }
     },
     "node_modules/dom-input-range": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-1.1.5.tgz",
-      "integrity": "sha512-ITURvugfDoy8Wk8JC6NoI4dKyLPR4qbFnXJ+V+qVpQtTmDgT8HZjH2iNUIMiEU1kkdWEMLgDxYTSXJnPz9aeiA=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-1.1.6.tgz",
+      "integrity": "sha512-4o/SkTpscD0n81BeErrrtmE58lG8vTks++92vk//ld0NmkQTb4AVJ2rexh2yor6rtBf5IMte26u+fF3EgCppPQ=="
     },
     "node_modules/dom-serialize": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "prettier": "@github/prettier-config",
   "dependencies": {
     "@github/combobox-nav": "^2.0.2",
-    "dom-input-range": "^1.1.3"
+    "dom-input-range": "^1.1.6"
   },
   "devDependencies": {
     "@github/prettier-config": "0.0.4",


### PR DESCRIPTION
Updates `dom-input-range` to `1.1.6` to fix `DOMException` errors. The dependency was throwing exceptions when the custom element was registered a second time, which would happen on soft navigations. This was resolved in https://github.com/iansan5653/dom-input-range/pull/4