### PR TITLE
Fix positioning error

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -4,8 +4,15 @@
     <meta charset="utf-8" />
     <title>text-expander demo</title>
     <style>
-      [aria-selected='true'] {
-        background: #eee;
+      .menu {
+        position: absolute;
+        list-style-type: none;
+        padding: 0;
+        background: lightgray;
+
+        [aria-selected='true'] {
+          background: #eee;
+        }
       }
     </style>
   </head>
@@ -30,6 +37,7 @@
           const {key, provide, text} = event.detail
           if (key === '#') {
             const menu = document.createElement('ul')
+            menu.classList.add('menu')
             menu.role = 'listbox'
             for (const issue of [
               '#1 Implement a text-expander element',


### PR DESCRIPTION
Fixes a bug where the menu position would be calculated incorrectly because `dom-input-range` gives absolute positions and we were still offsetting by the position of the input.

This approach should be generally more robust by re-adjusting the position if necessary after setting it.
