### PR TITLE
Update dom-input-range to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.0.2",
-        "dom-input-range": "^1.1.6"
+        "dom-input-range": "^1.2.0"
       },
       "devDependencies": {
         "@github/prettier-config": "0.0.4",
@@ -1611,9 +1611,9 @@
       }
     },
     "node_modules/dom-input-range": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-1.1.6.tgz",
-      "integrity": "sha512-4o/SkTpscD0n81BeErrrtmE58lG8vTks++92vk//ld0NmkQTb4AVJ2rexh2yor6rtBf5IMte26u+fF3EgCppPQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-1.2.0.tgz",
+      "integrity": "sha512-8HVA5Oy5Vt872S7IXsjjp6/5Hqsm5YZLhurxwwQXp80T9qVsj8/mEUH3sQlFujLLUoWfxiaThHHuJ3/q1MHVuA=="
     },
     "node_modules/dom-serialize": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "prettier": "@github/prettier-config",
   "dependencies": {
     "@github/combobox-nav": "^2.0.2",
-    "dom-input-range": "^1.1.6"
+    "dom-input-range": "^1.2.0"
   },
   "devDependencies": {
     "@github/prettier-config": "0.0.4",


### PR DESCRIPTION
Release notes:

> * Allow `InputStyleCloneElement` to be constructed directly (https://github.com/iansan5653/dom-input-range/pull/6). This fixes errors thrown when cloning the element and also allows for direct construction when using the registry is not possible:
> 
>   ```js
>   const clone = new InputStyleCloneElement()
>   clone.connect(targetInputElement)
>   ```

This fixes #64