### PR TITLE
Add keys setter

### DIFF
--- a/src/text-expander-element.ts
+++ b/src/text-expander-element.ts
@@ -276,6 +276,10 @@ export default class TextExpanderElement extends HTMLElement {
     return keys.map(key => ({key, multiWord: globalMultiWord || multiWord.includes(key)}))
   }
 
+  set keys(value: string) {
+    this.setAttribute('keys', value)
+  }
+
   connectedCallback(): void {
     const input = this.querySelector('input[type="text"], textarea')
     if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) return

--- a/test/text-expander-element-test.js
+++ b/test/text-expander-element-test.js
@@ -192,6 +192,28 @@ describe('text-expander element', function () {
       )
     })
 
+    it('sets keys', function () {
+      const expander = document.querySelector('text-expander')
+      assert.deepEqual(
+        [
+          {key: '@', multiWord: false},
+          {key: '#', multiWord: true},
+          {key: '[[', multiWord: true}
+        ],
+        expander.keys
+      )
+
+      expander.keys = '@ [['
+
+      assert.deepEqual(
+        [
+          {key: '@', multiWord: false},
+          {key: '[[', multiWord: true}
+        ],
+        expander.keys
+      )
+    })
+
     it('dispatches change event for multi-word', async function () {
       const expander = document.querySelector('text-expander')
       const input = expander.querySelector('textarea')


### PR DESCRIPTION
fixes https://github.com/github/text-expander-element/issues/62

Adds a keys setter so that react 19 can properly call set on the property.

React 19 does an `prop in Obj` check for whether to set properties or attributes, and since `keys` is found due to the getter it attempts to set that property on the javascript object instead of the attribute.  leading to an error since no setter is defined

this forwards the property setter to the attribute setter directly