### PR TITLE
Fixes a typo in the README: dectivate → deactivate

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ expander.addEventListener('text-expander-committed', function(event) {
 
 **`text-expander-activate`** is fired just after the menu has been assigned and appended to the DOM, and just before it is about to be positioned near the text to expand. This is useful for assigning classes or calling imperative methods to show the menu, such as `.showPopover()`.
 
-**`text-expander-dectivate`** is fired just before the menu is goind to be unassigned and removed from the DOM. This is useful for removing classes or running cleanup like removing from caches.
+**`text-expander-deactivate`** is fired just before the menu is goind to be unassigned and removed from the DOM. This is useful for removing classes or running cleanup like removing from caches.
 
 ## Browser support
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ expander.addEventListener('text-expander-committed', function(event) {
 
 **`text-expander-activate`** is fired just after the menu has been assigned and appended to the DOM, and just before it is about to be positioned near the text to expand. This is useful for assigning classes or calling imperative methods to show the menu, such as `.showPopover()`.
 
-**`text-expander-deactivate`** is fired just before the menu is goind to be unassigned and removed from the DOM. This is useful for removing classes or running cleanup like removing from caches.
+**`text-expander-deactivate`** is fired just before the menu is going to be unassigned and removed from the DOM. This is useful for removing classes or running cleanup like removing from caches.
 
 ## Browser support
 


### PR DESCRIPTION
Was using the events API of the component, and noticed that one event was not working: it ended up being a typo in the docs.