### PR TITLE
Re-export the types in index.d.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import TextExpanderElement from './text-expander-element'
 export {TextExpanderElement as default}
+export type * from './text-expander-element'
 
 declare global {
   interface Window {


### PR DESCRIPTION
Followup to https://github.com/github/text-expander-element/pull/72.

I'm sorry I missed this. This makes it possible to import the types from `@github/text-expander-element` directly instead of having to import from `@github/text-expander-element/dist/text-expander-element.d.ts`.

The specific `export type *` syntax is supported since [Typescript 5.0](https://github.com/microsoft/TypeScript/pull/52217).