### PR TITLE
Upgrade dom-input-range to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.0.2",
-        "dom-input-range": "^1.2.0"
+        "dom-input-range": "^2.0.0"
       },
       "devDependencies": {
         "@github/prettier-config": "0.0.4",
@@ -1611,9 +1611,9 @@
       }
     },
     "node_modules/dom-input-range": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-1.2.0.tgz",
-      "integrity": "sha512-8HVA5Oy5Vt872S7IXsjjp6/5Hqsm5YZLhurxwwQXp80T9qVsj8/mEUH3sQlFujLLUoWfxiaThHHuJ3/q1MHVuA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-input-range/-/dom-input-range-2.0.0.tgz",
+      "integrity": "sha512-sN7l/rHFZitltYrmf9B7HlXu97wgEUVquxWQmY1IpTOKVoP56mnut73MtBRtMM2zjBRhQOF59BSYFuIHqUsRow=="
     },
     "node_modules/dom-serialize": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "prettier": "@github/prettier-config",
   "dependencies": {
     "@github/combobox-nav": "^2.0.2",
-    "dom-input-range": "^1.2.0"
+    "dom-input-range": "^2.0.0"
   },
   "devDependencies": {
     "@github/prettier-config": "0.0.4",


### PR DESCRIPTION
Upgrades the `dom-input-range` dependency to [version 2.x](https://github.com/iansan5653/dom-input-range/releases/tag/v2.0.0) so that we can use it elsewhere without multiple versions installed. There's no breaking changes since we're only using the `InputRange` API:

> There are no migration steps required for consumers using only the `InputRange` API. 